### PR TITLE
support GitHub Actions build docker image with CUDA device

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git/
+.github/
+.vscode/
+cache/
+docker/
+.gitignore
+build.sh
+dockerfile
+environment.yml
+# Ignore generated files
+**/*.pyc

--- a/.github/workflows/docker-image-tag-commit.yml
+++ b/.github/workflows/docker-image-tag-commit.yml
@@ -1,0 +1,93 @@
+
+name: Docker Image Build/Publish tag with commit
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: nsfw-detector commit id(like 'main' '095a6de3')
+        required: true
+        default: main
+
+jobs:
+  build-and-push-docker-image:
+    name: Build Docker image and push to repositories
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    strategy:
+      matrix:
+        BRANCH_CHECKOUT:
+          - ${{ github.event.inputs.commit_id || 'main' }}
+        platforms:
+          - linux/amd64
+
+    steps:
+      # Fix github action 'No space left on device'
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout commit
+        run: |
+          git checkout ${{ matrix.BRANCH_CHECKOUT }}
+
+      - name: Set env git short head
+        working-directory: .
+        run: echo "COMMIT_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Meta data image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/nsfw_detector
+            ghcr.io/${{ github.repository_owner }}/nsfw_detector
+          tags: |
+            type=raw,value=${{ matrix.BRANCH_CHECKOUT }}
+            type=raw,value=${{ env.COMMIT_SHORT }}
+          flavor: |
+            latest=false
+
+      - name: Build push image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/build@source/dockerfile
+          platforms: ${{ matrix.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Print image digest
+        run: echo ${{ steps.build.outputs.digest }}

--- a/.github/workflows/docker-image-tag-version.yml
+++ b/.github/workflows/docker-image-tag-version.yml
@@ -1,0 +1,90 @@
+
+name: Docker Image Build/Publish tag with version
+
+on:
+  push:
+    tags:
+      - "v*"
+    branches:
+      - 'main'
+    paths:
+      - docker/build@pypi/dockerfile
+      - .github/workflows/docker-image-tag-version.yml
+  workflow_dispatch:
+    inputs:
+      nsfwdetector_version:
+        description: nsfw-detector version of pypi
+        required: true
+        default: '1.7'
+
+jobs:
+  build-and-push-docker-image:
+    name: Build Docker image and push to repositories
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    strategy:
+      matrix:
+        NSFWDETECTOR_VERSION:
+          - ${{ github.event.inputs.nsfwdetector_version || '1.7' }}
+        platform:
+          - linux/amd64
+
+    steps:
+      # Fix github action 'No space left on device'
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Meta data image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/nsfw_detector
+            ghcr.io/${{ github.repository_owner }}/nsfw_detector
+          tags: |
+            type=raw,value=${{ matrix.NSFWDETECTOR_VERSION }}
+            type=raw,value=lastet
+          flavor: |
+            latest=false
+
+      - name: Build push image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/build@pypi/dockerfile
+          build-args: |
+            NSFWDETECTOR_VERSION=${{ matrix.NSFWDETECTOR_VERSION }}
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Print image digest
+        run: echo ${{ steps.build.outputs.digest }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# Ignore generated files
+**/*.pyc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "debugpy: app mirror",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/app.py",
+            "console": "integratedTerminal",
+            "env": {
+                "TRANSFORMERS_CACHE": "${workspaceFolder}/cache/huggingface/hub",
+                "HF_ENDPOINT": "https://hf-mirror.com",
+                "HF_HUB_ETAG_TIMEOUT": "1000",
+                "HF_HUB_DOWNLOAD_TIMEOUT": "1000"
+            },
+            "justMyCode": false
+        },
+        {
+            "name": "debugpy: app offline",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/app.py",
+            "console": "integratedTerminal",
+            "env": {
+                "TRANSFORMERS_CACHE": "${workspaceFolder}/cache/huggingface/hub",
+                "HF_HUB_OFFLINE": "true"
+            },
+            "justMyCode": false
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,72 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "docker: compose up@gpu-online",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/docker/up@gpu-online/"
+            },
+            "command": "docker compose -p nsfw_detector up"
+        },
+        {
+            "label": "docker: compose up@cpu-online",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/docker/up@cpu-online/"
+            },
+            "command": "docker compose -p nsfw_detector up"
+        },
+        {
+            "label": "docker: build main",
+            "type": "shell",
+            "command": "docker build -t vxlink/nsfw_detector:main -f ./docker/build@source/dockerfile ."
+        },
+        // no pypi package
+        // {
+        //     "label": "docker: build v1.7",
+        //     "type": "shell",
+        //     "command": "docker build -t vxlink/nsfw_detector:v1.7 -f ./docker/build@pypi/dockerfile ."
+        // },
+        {
+            "label": "huggingface-cli: download models",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "HF_ENDPOINT": "https://hf-mirror.com",
+                    "HF_HUB_ETAG_TIMEOUT": "1000",
+                    "HF_HUB_DOWNLOAD_TIMEOUT": "1000"
+                }
+            },
+            "command": [
+                "huggingface-cli download --revision main --cache-dir ./cache/huggingface/hub --include='*.json' Falconsai/nsfw_image_detection",
+                "&& huggingface-cli download --revision main --cache-dir ./cache/huggingface/hub --include='*.safetensors' Falconsai/nsfw_image_detection",
+            ]
+        },
+        {
+            "label": "conda: run app",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "HF_ENDPOINT": "https://hf-mirror.com",
+                    "HF_HUB_ETAG_TIMEOUT": "1000",
+                    "HF_HUB_DOWNLOAD_TIMEOUT": "1000",
+                    "TRANSFORMERS_CACHE": "${workspaceFolder}/cache/huggingface/hub",
+                }
+            },
+            "command": [
+                "conda run --no-capture-output -n nsfw_detector python app.py"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "conda: create env",
+            "type": "shell",
+            "command": [
+                "conda env create -f ./environment.yml"
+            ]
+        }
+    ]
+}

--- a/app.py
+++ b/app.py
@@ -4,12 +4,18 @@ import tempfile
 import os
 import shutil
 import logging
-import magic
 from pathlib import Path
 from werkzeug.utils import secure_filename
 from config import MAX_FILE_SIZE, IMAGE_EXTENSIONS, VIDEO_EXTENSIONS, MIME_TO_EXT
 from utils import ArchiveHandler, can_process_file, sort_files_by_priority
 from processors import process_image, process_pdf_file, process_video_file, process_archive
+
+import platform
+
+if platform.system() == "Windows":
+    from winmagic import magic
+else:
+    import magic
 
 # 配置日志
 logger = logging.getLogger(__name__)

--- a/cache/.gitignore
+++ b/cache/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/cache/README.md
+++ b/cache/README.md
@@ -1,0 +1,44 @@
+# cache
+
+This folder is the cache directory for Hugging Face (HF).
+
+When using online mode, downloaded models will be cached in this folder.
+
+For [offline mode](https://huggingface.co/docs/transformers/main/installation#offline-mode) use, please download the models in advance and specify the model directory,
+such as the `Falconsai/nsfw_image_detection` model below.
+
+The folder structure for `./cache/huggingface/hub/models--Falconsai--nsfw_image_detection` is as follows.
+
+```
+.
+├── blobs
+├── refs
+│   └── main
+└── snapshots
+    └── 63e0a066bb08d2ae47324b540fba3adfd4536569
+        ├── config.json
+        ├── model.safetensors
+        └── preprocessor_config.json
+
+5 directories, 4 files
+```
+
+For more details, refer to [up@cpu-offline/docker-compose.yml](./../docker/up@cpu-offline/docker-compose.yml).
+
+
+## Pre-download for offline mode
+
+Running in online mode will automatically download the model.
+
+install cli
+
+```bash
+pip install -U "huggingface_hub[cli]"
+```
+
+download model
+
+```bash
+huggingface-cli download --revision main --cache-dir ./cache/huggingface/hub --include='*.json' Falconsai/nsfw_image_detection
+huggingface-cli download --revision main --cache-dir ./cache/huggingface/hub --include='*.safetensors' Falconsai/nsfw_image_detection
+```

--- a/docker/build@pypi/dockerfile
+++ b/docker/build@pypi/dockerfile
@@ -1,0 +1,30 @@
+# ARG NSFWDETECTOR_VERSION=1.7
+
+
+# FROM pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
+
+# ARG NSFWDETECTOR_VERSION
+
+# WORKDIR /app
+
+# RUN apt-get update && apt-get install -y \
+#     python3-pip \
+#     libgl1-mesa-glx \
+#     libsm6 \
+#     libxext6 \
+#     libglib2.0-0 \
+#     libxrender-dev \
+#     libmagic1 \
+#     ffmpeg \
+#     p7zip-full p7zip-rar \
+#     && rm -rf /var/lib/apt/lists/*
+
+# RUN pip3 install --upgrade pip
+
+# RUN pip3 install --no-cache-dir nsfw-detector?==${NSFWDETECTOR_VERSION}
+
+# EXPOSE 3333
+
+# VOLUME /root/.cache
+
+# CMD ["python", "app.py"]

--- a/docker/build@source/dockerfile
+++ b/docker/build@source/dockerfile
@@ -1,0 +1,29 @@
+
+FROM pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    python3-pip \
+    libgl1-mesa-glx \
+    libsm6 \
+    libxext6 \
+    libglib2.0-0 \
+    libxrender-dev \
+    libmagic1 \
+    ffmpeg \
+    p7zip-full p7zip-rar \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --upgrade pip
+
+COPY ./requirements.txt /app/requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 3333
+
+VOLUME /root/.cache
+
+CMD ["python", "app.py"]

--- a/docker/up@cpu-offline/docker-compose.yml
+++ b/docker/up@cpu-offline/docker-compose.yml
@@ -1,0 +1,13 @@
+
+
+services:
+  nsfw_detector:
+    image: vxlink/nsfw_detector:1.0.0
+    container_name: nsfw_detector_flask
+    environment:
+      - TORCH_DEVICE=cpu
+      - HF_HUB_OFFLINE=true
+    ports:
+      - "3333:3333"
+    volumes:
+      - ./../../cache:/root/.cache

--- a/docker/up@cpu-online/docker-compose.yml
+++ b/docker/up@cpu-online/docker-compose.yml
@@ -1,0 +1,12 @@
+
+
+services:
+  nsfw_detector:
+    image: vxlink/nsfw_detector:main
+    container_name: nsfw_detector_flask
+    environment:
+      - TORCH_DEVICE=cpu
+    ports:
+      - "3333:3333"
+    volumes:
+      - ./../../cache:/root/.cache

--- a/docker/up@gpu-offline/docker-compose.yml
+++ b/docker/up@gpu-offline/docker-compose.yml
@@ -1,0 +1,19 @@
+
+
+services:
+  nsfw_detector:
+    image: vxlink/nsfw_detector:1.0.0
+    container_name: nsfw_detector_flask
+    environment:
+      - TORCH_DEVICE=cuda
+      - HF_HUB_OFFLINE=true
+    ports:
+      - "3333:3333"
+    volumes:
+      - ./../../cache:/root/.cache
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [ gpu ]

--- a/docker/up@gpu-online/docker-compose.yml
+++ b/docker/up@gpu-online/docker-compose.yml
@@ -1,0 +1,18 @@
+
+
+services:
+  nsfw_detector:
+    image: vxlink/nsfw_detector:main
+    container_name: nsfw_detector_flask
+    environment:
+      - TORCH_DEVICE=cuda
+    ports:
+      - "3333:3333"
+    volumes:
+      - ./../../cache:/root/.cache
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [ gpu ]

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: nsfw_detector
+channels:
+  - conda-forge
+  - pytorch
+  - nvidia
+dependencies:
+  - python=3.10.12
+
+  - pytorch==2.4.1
+  - pytorch-cuda==12.4
+
+  - pip:
+    - python-magic-win64==0.4.13
+    - -r requirements.txt

--- a/processors.py
+++ b/processors.py
@@ -1,4 +1,5 @@
 # processors.py
+import torch
 from transformers import pipeline
 import subprocess
 import numpy as np
@@ -21,8 +22,12 @@ from config import (
 # 配置日志
 logger = logging.getLogger(__name__)
 
+# GPU加速
+device = 'cuda' if torch.cuda.is_available() else -1
+logger.info(f"处理设备: device={device}")
+
 # 初始化模型
-pipe = pipeline("image-classification", model="Falconsai/nsfw_image_detection", device=-1)
+pipe = pipeline("image-classification", model="Falconsai/nsfw_image_detection", device=device)
 
 class VideoProcessor:
     def __init__(self, video_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+python-magic    # Automatically select to be compatible with python-magic-win64.
+opencv-python-headless==4.10.0.84
+rarfile==4.2
+py7zr==0.22.0
+flask==2.0.1
+werkzeug==2.0.3
+Pillow==11.0.0
+transformers==4.46.3
+PyMuPDF==1.24.14


### PR DESCRIPTION
A Docker image is built via GitHub Actions and pushed to Docker Hub and the GitHub Container Registry.

Using CUDA to detect 200 keyframes in a video significantly improves the processing speed. Since CUDA is rarely available on ARM64, this platform version is not provided. Perhaps the CUDA version should use a new image name to distinguish it.

You need to create Docker Hub personal access tokens and configure GitHub Actions secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN.

Additionally, a VS Code task launch configuration has been added for running build and debug tasks, though this is merely for convenience.

Currently, there will be two types of tagged images with different build sources, see [docker hub](https://hub.docker.com/r/xiaoyao9184/nsfw_detector/tags) and [github pkgs](https://github.com/xiaoyao9184/nsfw_detector/pkgs/container/nsfw_detector/versions).

Images tagged with the branch name or short commit ID are built from source code, typically triggered by commits to the `main` branch.
Images tagged with version numbers or `latest` were intended to be built using PyPI release packages. However, since the original project lacks PyPI support, this workflow and dockerfile have been commented out. You can expect to see a perpetually [failing](https://github.com/xiaoyao9184/nsfw_detector/actions) CI workflow.
Both builds support manual triggering. Therefore, you can manually trigger the first task and provide a tag name, such as `v1.7.1` (a future tag), to build the specified version.